### PR TITLE
Future days in same month should be disabled

### DIFF
--- a/app/src/main/java/com/yonder/weightly/ui/add/AddWeightFragment.kt
+++ b/app/src/main/java/com/yonder/weightly/ui/add/AddWeightFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.datepicker.CalendarConstraints
+import com.google.android.material.datepicker.DateValidatorPointBackward
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.yonder.weightly.R
 import com.yonder.weightly.databinding.FragmentAddWeightBinding
@@ -84,6 +85,7 @@ class AddWeightFragment : BottomSheetDialogFragment() {
             val startFrom = calendar.timeInMillis
             val constraints = CalendarConstraints.Builder()
                 .setEnd(startFrom)
+                .setValidator(DateValidatorPointBackward.now())
                 .build()
 
             val datePicker =


### PR DESCRIPTION
Users are able to set their weight for future days in the month. Maximum day to set weight should be today and future days in same month should be disabled.

**Actual Result**
<img src="https://user-images.githubusercontent.com/25232658/175784758-0948befd-72b2-42d0-9fed-772dc62f4ee4.jpeg" width="300" />

**Expected Result**
<img src="https://user-images.githubusercontent.com/25232658/175784805-13d3707c-7d43-4749-b077-efb7aa0f2762.jpeg" width="300" />

