### PR TITLE
Fix the keyboard is overlapping on bottom sheet

### DIFF
--- a/app/src/main/java/com/yonder/weightly/ui/add/AddWeightFragment.kt
+++ b/app/src/main/java/com/yonder/weightly/ui/add/AddWeightFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -38,6 +39,11 @@ class AddWeightFragment : BottomSheetDialogFragment() {
 
     private var selectedDate = Date()
     private var emoji: String = String.EMPTY
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(DialogFragment.STYLE_NORMAL, R.style.BottomSheetDialogStyle)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BottomSheetDialogStyle" parent="Theme.Material3.Light.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
+</resources>


### PR DESCRIPTION
Keyboard is overlapping on the edit text fields. And it might be hard to reach update and delete buttons since we can't scroll the bottom sheet to the up while note field has focus.